### PR TITLE
Added IBM to List of Participating Companies

### DIFF
--- a/Participating-in-the-InnerSource-Commons.md
+++ b/Participating-in-the-InnerSource-Commons.md
@@ -1,6 +1,7 @@
 ## List of participating companies and institutions
 * [Bitergia](https://bitergia.com), 2016
 * [Harvard Business Review](https://hbr.org)
+* [IBM](https://ibm.com), 2018
 * [PayPal](http://paypal.com/)
 * [Robert Bosch GmbH](https://www.bosch.com)
 * [O'Reilly Media](https://oreilly.com/), 2017


### PR DESCRIPTION
IBM began InnerSource for several of its internal projects around 2018, including, in particular, IBM Watson Health.  It also engages with client organizations that are interested in adopting open source and InnerSource strategies internally by providing consulting services that guide them on the InnerSource Commons principles and lessons learned from its member organizations.